### PR TITLE
add `AcquisitionDuration`

### DIFF
--- a/sub-10062Ses1/anat/sub-10062Ses1_run-1_T2starw.json
+++ b/sub-10062Ses1/anat/sub-10062Ses1_run-1_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 3,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Prisma",
-	"InstitutionName": "CEITEC"
+	"InstitutionName": "CEITEC",
+	"AcquisitionDuration": "227"
 }

--- a/sub-10062Ses1/anat/sub-10062Ses1_run-2_T2starw.json
+++ b/sub-10062Ses1/anat/sub-10062Ses1_run-2_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 3,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Prisma",
-	"InstitutionName": "CEITEC"
+	"InstitutionName": "CEITEC",
+	"AcquisitionDuration": "227"
 }

--- a/sub-10062Ses2/anat/sub-10062Ses2_run-1_T2starw.json
+++ b/sub-10062Ses2/anat/sub-10062Ses2_run-1_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 3,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Prisma",
-	"InstitutionName": "CEITEC"
+	"InstitutionName": "CEITEC",
+	"AcquisitionDuration": "476"
 }

--- a/sub-10062Ses2/anat/sub-10062Ses2_run-2_T2starw.json
+++ b/sub-10062Ses2/anat/sub-10062Ses2_run-2_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 3,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Prisma",
-	"InstitutionName": "CEITEC"
+	"InstitutionName": "CEITEC",
+	"AcquisitionDuration": "476"
 }

--- a/sub-20210728/anat/sub-20210728_run-1_T2starw.json
+++ b/sub-20210728/anat/sub-20210728_run-1_T2starw.json
@@ -1355,5 +1355,6 @@
 			"SizeOfPixelData": 4294967295,
 			"VROfPixelData": "OB"
 		}
-	]
+	],
+	"AcquisitionDuration": "603"
 }

--- a/sub-20210728/anat/sub-20210728_run-2_T2starw.json
+++ b/sub-20210728/anat/sub-20210728_run-2_T2starw.json
@@ -1358,5 +1358,6 @@
 			"SizeOfPixelData": 4294967295,
 			"VROfPixelData": "OB"
 		}
-	]
+	],
+	"AcquisitionDuration": "603"
 }

--- a/sub-9418/anat/sub-9418_run-1_T2starw.json
+++ b/sub-9418/anat/sub-9418_run-1_T2starw.json
@@ -4,5 +4,6 @@
 	"Manufacturer": "Philips",
 	"ManufacturersModelName": "Achieva",
 	"InstitutionName": "University College London",
-	"SoftwareVersions": "3.2.1"
+	"SoftwareVersions": "3.2.1",
+	"AcquisitionDuration": "594.3"
 }

--- a/sub-9418/anat/sub-9418_run-2_T2starw.json
+++ b/sub-9418/anat/sub-9418_run-2_T2starw.json
@@ -4,5 +4,6 @@
 	"Manufacturer": "Philips",
 	"ManufacturersModelName": "Achieva",
 	"InstitutionName": "University College London",
-	"SoftwareVersions": "3.2.1"
+	"SoftwareVersions": "3.2.1",
+	"AcquisitionDuration": "594.3"
 }

--- a/sub-9584/anat/sub-9584_run-1_T2starw.json
+++ b/sub-9584/anat/sub-9584_run-1_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 3,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Prisma fit",
-	"InstitutionName": "North-West University"
+	"InstitutionName": "North-West University",
+	"AcquisitionDuration": "352"
 }

--- a/sub-9584/anat/sub-9584_run-2_T2starw.json
+++ b/sub-9584/anat/sub-9584_run-2_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 3,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Prisma fit",
-	"InstitutionName": "North-West University"
+	"InstitutionName": "North-West University",
+	"AcquisitionDuration": "352"
 }

--- a/sub-9604/anat/sub-9604_run-1_T2starw.json
+++ b/sub-9604/anat/sub-9604_run-1_T2starw.json
@@ -4,5 +4,6 @@
 	"Manufacturer": "Philips",
 	"ManufacturersModelName": "Achieva",
 	"InstitutionName": "CHUM",
-	"SoftwareVersions": "R5.3.0.3"
+	"SoftwareVersions": "R5.3.0.3",
+	"AcquisitionDuration": "353.7"
 }

--- a/sub-9604/anat/sub-9604_run-2_T2starw.json
+++ b/sub-9604/anat/sub-9604_run-2_T2starw.json
@@ -4,5 +4,6 @@
 	"Manufacturer": "Philips",
 	"ManufacturersModelName": "Achieva",
 	"InstitutionName": "CHUM",
-	"SoftwareVersions": "R5.3.0.3"
+	"SoftwareVersions": "R5.3.0.3",
+	"AcquisitionDuration": "353.7"
 }

--- a/sub-9605/anat/sub-9605_run-1_T2starw.json
+++ b/sub-9605/anat/sub-9605_run-1_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 7,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Mount Sinai"
+	"InstitutionName": "Mount Sinai",
+	"AcquisitionDuration": "167"
 }

--- a/sub-9605/anat/sub-9605_run-2_T2starw.json
+++ b/sub-9605/anat/sub-9605_run-2_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 7,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Mount Sinai"
+	"InstitutionName": "Mount Sinai",
+	"AcquisitionDuration": "167"
 }

--- a/sub-9611Ses1/anat/sub-9611Ses1_run-1_T2starw.json
+++ b/sub-9611Ses1/anat/sub-9611Ses1_run-1_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 7,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Oxford"
+	"InstitutionName": "Oxford",
+	"AcquisitionDuration": "353"
 }

--- a/sub-9611Ses1/anat/sub-9611Ses1_run-2_T2starw.json
+++ b/sub-9611Ses1/anat/sub-9611Ses1_run-2_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 7,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Oxford"
+	"InstitutionName": "Oxford",
+	"AcquisitionDuration": "353"
 }

--- a/sub-9611Ses2/anat/sub-9611Ses2_run-1_T2starw.json
+++ b/sub-9611Ses2/anat/sub-9611Ses2_run-1_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 7,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Oxford"
+	"InstitutionName": "Oxford",
+	"AcquisitionDuration": "353"
 }

--- a/sub-9611Ses2/anat/sub-9611Ses2_run-2_T2starw.json
+++ b/sub-9611Ses2/anat/sub-9611Ses2_run-2_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 7,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Oxford"
+	"InstitutionName": "Oxford",
+	"AcquisitionDuration": "353"
 }

--- a/sub-9611Ses3/anat/sub-9611Ses3_run-1_T2starw.json
+++ b/sub-9611Ses3/anat/sub-9611Ses3_run-1_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 7,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Oxford"
+	"InstitutionName": "Oxford",
+	"AcquisitionDuration": "353"
 }

--- a/sub-9611Ses3/anat/sub-9611Ses3_run-2_T2starw.json
+++ b/sub-9611Ses3/anat/sub-9611Ses3_run-2_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 7,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Oxford"
+	"InstitutionName": "Oxford",
+	"AcquisitionDuration": "353"
 }

--- a/sub-9669/anat/sub-9669_run-1_T2starw.json
+++ b/sub-9669/anat/sub-9669_run-1_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 3,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Juntendo"
+	"InstitutionName": "Juntendo",
+	"AcquisitionDuration": "285"
 }

--- a/sub-9669/anat/sub-9669_run-2_T2starw.json
+++ b/sub-9669/anat/sub-9669_run-2_T2starw.json
@@ -2,5 +2,6 @@
 	"Modality": "MR",
 	"MagneticFieldStrength": 3,
 	"Manufacturer": "Siemens",
-	"InstitutionName": "Juntendo"
+	"InstitutionName": "Juntendo",
+	"AcquisitionDuration": "285"
 }

--- a/sub-9709Ses1/anat/sub-9709Ses1_run-1_T2starw.json
+++ b/sub-9709Ses1/anat/sub-9709Ses1_run-1_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 1.5,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Avanto",
-	"InstitutionName": "Milan"
+	"InstitutionName": "Milan",
+	"AcquisitionDuration": "195"
 }

--- a/sub-9709Ses1/anat/sub-9709Ses1_run-2_T2starw.json
+++ b/sub-9709Ses1/anat/sub-9709Ses1_run-2_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 1.5,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Avanto",
-	"InstitutionName": "Milan"
+	"InstitutionName": "Milan",
+	"AcquisitionDuration": "195"
 }

--- a/sub-9709Ses2/anat/sub-9709Ses2_run-1_T2starw.json
+++ b/sub-9709Ses2/anat/sub-9709Ses2_run-1_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 1.5,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Avanto",
-	"InstitutionName": "Milan"
+	"InstitutionName": "Milan",
+	"AcquisitionDuration": "482"
 }

--- a/sub-9709Ses2/anat/sub-9709Ses2_run-1_T2starw.json
+++ b/sub-9709Ses2/anat/sub-9709Ses2_run-1_T2starw.json
@@ -4,5 +4,5 @@
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Avanto",
 	"InstitutionName": "Milan",
-	"AcquisitionDuration": "482"
+	"AcquisitionDuration": "462"
 }

--- a/sub-9709Ses2/anat/sub-9709Ses2_run-2_T2starw.json
+++ b/sub-9709Ses2/anat/sub-9709Ses2_run-2_T2starw.json
@@ -3,5 +3,6 @@
 	"MagneticFieldStrength": 1.5,
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Avanto",
-	"InstitutionName": "Milan"
+	"InstitutionName": "Milan",
+	"AcquisitionDuration": "482"
 }

--- a/sub-9709Ses2/anat/sub-9709Ses2_run-2_T2starw.json
+++ b/sub-9709Ses2/anat/sub-9709Ses2_run-2_T2starw.json
@@ -4,5 +4,5 @@
 	"Manufacturer": "Siemens",
 	"ManufacturersModelName": "Avanto",
 	"InstitutionName": "Milan",
-	"AcquisitionDuration": "482"
+	"AcquisitionDuration": "462"
 }


### PR DESCRIPTION
Units of `AcquisitionDuration` in seconds based on https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html

Fixes https://github.com/sct-pipeline/gm-challenge-data/issues/25